### PR TITLE
Export the newestSpace function

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,9 +366,9 @@ isSpace({}); // returns false
 
 Parameter: A space
 
-Returns: The the deepest root space associated with the given space.
+Returns: The root space associated with the given space.
 
-**Note**: Returns the latest root space of the passed in space. This means you can safely do `rootOf(space)` anywhere in a custom action, and always get the latest version.
+**Note**: This function goes all the way up in the chain of parent spaces, returning the latest root space of the parameter. This means you can safely do `rootOf(space)` anywhere in a custom action, and always get the latest version.
 
 ```js
 import { createSpace, rootOf } from 'spaceace';
@@ -388,8 +388,6 @@ space.user(({ merge, space }, name) => {
 Parameter: A space
 
 Returns: The newest copy of the space, at the same level.
-
-**Note**: This is a sister function of `rootOf(space)`, however where `rootOf(space)` returns the deepest root, this one returns the newest copy of the current level.
 
 ```js
 import { createSpace, newestSpace } from 'spaceace';

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ isSpace({}); // returns false
 
 Parameter: A space
 
-Returns: The root space associated with the given space.
+Returns: The the deepest root space associated with the given space.
 
 **Note**: Returns the latest root space of the passed in space. This means you can safely do `rootOf(space)` anywhere in a custom action, and always get the latest version.
 
@@ -381,6 +381,24 @@ space.user(({ merge, space }, name) => {
   merge({ name });
   rootOf(space).user.name === 'Sam'; // true
 })('Sam');
+```
+
+### newestSpace
+
+Parameter: A space
+
+Returns: The newest copy of the space, at the same level.
+
+**Note**: This is a sister function of `rootOf(space)`, however where `rootOf(space)` returns the deepest root, this one returns the newest copy of the current level.
+
+```js
+import { createSpace, newestSpace } from 'spaceace';
+
+const space = createSpace({ user: { name: 'Frodo' } });
+const latestSnapshot = space.user({ name: 'Sam' });
+
+latestSnapshot.name === 'Sam'; // true
+newestSpace(space.user).name === 'Sam'; // true
 ```
 
 ## toJSON

--- a/lib/Space.d.ts
+++ b/lib/Space.d.ts
@@ -46,6 +46,7 @@ interface Subscriber {
 }
 
 export function rootOf(space: Space): Space;
+export function newestSpace(space: Space): Space;
 export function isSpace(space: Space | any): boolean;
 export function subscribe(subscriber: Subscriber): boolean;
 export function createSpace(initialState: object): Space;

--- a/lib/Space.js
+++ b/lib/Space.js
@@ -262,6 +262,7 @@
   Space.isSpace = isSpace;
   Space.rootOf = rootOf;
   Space.createSpace = createSpace;
+  Space.newestSpace = newestSpace;
 
   /* Instance methods */
 

--- a/test/main.js
+++ b/test/main.js
@@ -115,7 +115,7 @@ describe('Space', function() {
         assert.strictEqual(rootOf(this.space.characters[0]), this.space);
       });
 
-      it('returns the deepest root space', function() {
+      it('goes all the way up the chain of parent spaces', function() {
         assert.strictEqual(rootOf(this.space.userInfo.location), this.space);
       });
 

--- a/test/main.js
+++ b/test/main.js
@@ -2,7 +2,13 @@
 'use strict';
 
 const assert = require('assert');
-const { createSpace, subscribe, isSpace, rootOf } = require('../lib/Space');
+const {
+  createSpace,
+  subscribe,
+  isSpace,
+  rootOf,
+  newestSpace,
+} = require('../lib/Space');
 
 describe('Space', function() {
   beforeEach(function() {
@@ -109,10 +115,32 @@ describe('Space', function() {
         assert.strictEqual(rootOf(this.space.characters[0]), this.space);
       });
 
+      it('returns the deepest root space', function() {
+        assert.strictEqual(rootOf(this.space.userInfo.location), this.space);
+      });
+
+      it('returns the newest copy of the root space', function() {
+        this.space.userInfo.location({ city: 'San Diego' });
+        assert.strictEqual(rootOf(this.space.userInfo.location), this.newSpace);
+      });
+
       it('throws when given non-space', function() {
         assert.throws(() => {
           rootOf({});
         });
+      });
+    });
+
+    describe('.newestSpace', function() {
+      it('returns the same object if no updates were made', function() {
+        const capture = this.space.userInfo;
+        assert.strictEqual(newestSpace(capture), capture);
+      });
+
+      it('returns newest copy of current space', function() {
+        const capture = this.space.userInfo.location;
+        const newerSpace = capture({ city: 'San Diego' });
+        assert.strictEqual(newestSpace(capture), newerSpace);
       });
     });
 


### PR DESCRIPTION
Export the `newestSpace(space)` function, so that the users are able to obtain the newest copy of the space snapshot at the same level. 

This is pretty much half of the functionality provided by `rootOf(space)`, but it doesn't require the user to traverse the object tree from the very root. 