### PR TITLE
Remove const

### DIFF
--- a/lib/Space.js
+++ b/lib/Space.js
@@ -320,7 +320,7 @@
       throw new Error('Call rootOf with spaces only');
     }
 
-    const parent = newestSpace(space)._parent;
+    var parent = newestSpace(space)._parent;
     if (parent) return rootOf(parent);
     return newestSpace(space);
   }


### PR DESCRIPTION
`const` is not supported everywhere specifically in some mobile browsers.